### PR TITLE
Fix comment referencing twofile2.cpp

### DIFF
--- a/CppPrimerPlus/Chapter 9/twofile1.cpp
+++ b/CppPrimerPlus/Chapter 9/twofile1.cpp
@@ -1,5 +1,5 @@
 // twofile1.cpp -- variables with external and internal linkage
-#include <iostream>     // to be compiled with two file2.cpp
+#include <iostream>     // to be compiled with twofile2.cpp
 int tom = 3;            // external variable definition
 int dick = 30;          // external variable definition
 static int harry = 300; // static, internal linkage


### PR DESCRIPTION
## Summary
- correct the comment in `twofile1.cpp` to reference the correct companion file `twofile2.cpp`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843cb1e2f988329894c282d1d828917