### PR TITLE
Fix typo in .gitignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-CppPremierPlus/**/*.exe
+CppPrimerPlus/**/*.exe
 test.exe


### PR DESCRIPTION
## Summary
- correct `CppPrimerPlus` path in `.gitignore`

## Testing
- `g++ -std=c++17 test.cpp -o test && ./test <<EOF`
  `John Doe`
  `30`
  `EOF`


------
https://chatgpt.com/codex/tasks/task_e_6843cb1787a08329b9d501dceb51514f